### PR TITLE
packets: handle interactions on parents or widgets without children

### DIFF
--- a/runelite-client/src/main/java/dev/hoot/api/packets/Packets.java
+++ b/runelite-client/src/main/java/dev/hoot/api/packets/Packets.java
@@ -312,10 +312,10 @@ public class Packets
 					break;
 				}
 
-				var child = widget.getChild(param0);
+				var child = param0 == -1 ? null : widget.getChild(param0);
 				if (child == null)
 				{
-					break;
+					return WidgetPackets.createDefaultAction(id, param1, -1, param0);
 				}
 
 				return WidgetPackets.createDefaultAction(id, param1, child.getItemId(), param0);


### PR DESCRIPTION
This fixes array out of bound exceptions when interacting with a parent widget directly. The spec button (593, 36) for example has children but the interaction happens on the parent itself. Combat.toggleSpec() would throw an array out of bounds exception without this fix.