### PR TITLE
packets: set destination on movement packet creation

### DIFF
--- a/runelite-client/src/main/java/dev/hoot/api/packets/MovementPackets.java
+++ b/runelite-client/src/main/java/dev/hoot/api/packets/MovementPackets.java
@@ -44,6 +44,8 @@ public class MovementPackets
 		packetBufferNode.getPacketBuffer().writeByteAdd(ctrlDown ? 2 : 0);
 		packetBufferNode.getPacketBuffer().writeShortLE(worldPointX);
 		packetBufferNode.getPacketBuffer().writeShortLE(worldPointY);
+		client.setDestinationX(worldPointX);
+		client.setDestinationY(worldPointY);
 		return packetBufferNode;
 	}
 }


### PR DESCRIPTION
Using packets for movement doesn't set the destination in the client which makes isWalking() in the Movement API always return false.