### PR TITLE
api: Fix error on parsing wildy widget text

### DIFF
--- a/runelite-client/src/main/java/net/unethicalite/api/game/Game.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/game/Game.java
@@ -79,7 +79,11 @@ public class Game
 			return Integer.MAX_VALUE;
 		}
 		String widgetText = wildyLevelWidget.getText();
-		return Integer.parseInt(widgetText.substring(0, widgetText.indexOf('<')).replace("Level: ", ""));
+		if (widgetText.equals(""))
+		{
+			return 0;
+		}
+		return Integer.parseInt(widgetText.replace("Level: ", ""));
 	}
 
 	public static int getMembershipDays()


### PR DESCRIPTION
Fixes `StringIndexOutOfBoundsException: begin 0, end -1, length 8` error, seems like maybe the widget text changed because it only holds e.g. `Level: 15` at current time.